### PR TITLE
Fix tag library names in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,11 +43,11 @@ Usage
 -----
 
 Once you've created some instances of the ``flatblocks.models.FlatBlock``
-model, you can load it it using the ``flatblock_tags`` templatetag-library:
+model, you can load it it using the ``flatblocks`` templatetag-library:
 
 .. code-block:: html+django
 
-    {% load flatblock %}
+    {% load flatblocks %}
 
     <html>
         <head>


### PR DESCRIPTION
README.rst seemed to be a bit off with the names of the template tag library. This should fix it.